### PR TITLE
Update application-lifecycle-management-alm-with-unity-apps.md

### DIFF
--- a/docs/cross-platform/application-lifecycle-management-alm-with-unity-apps.md
+++ b/docs/cross-platform/application-lifecycle-management-alm-with-unity-apps.md
@@ -42,7 +42,7 @@ Visual Studio、Azure DevOps Services 和 Team Foundation Server 提供了各种
 
 参考链接：[对体系结构进行分析和建模](../modeling/analyze-and-model-your-architecture.md)
 
-常规注释：虽然这些设计功能既不依赖于编码语言，也不使用 C# 等 .NET 语言，但是它们运行于具有对象层次结构和类关系的传统应用程序范例上。 在 Unity 中设计游戏将包括不同的范例，即图形对象、声音、着色器、脚本等关系。 出于此原因，Visual Studio 建模关系图工具不是特别适全于整个 Unity 项目。 它们可能被用于管理 C# 脚本内的关系，但这只有全体中的一个部分。
+常规注释：虽然这些设计功能既不依赖于编码语言，也不使用 C# 等 .NET 语言，但是它们运行于具有对象层次结构和类关系的传统应用程序范例上。 在 Unity 中设计游戏将包括不同的范例，即图形对象、声音、着色器、脚本等关系。 出于此原因，Visual Studio 建模关系图工具不是特别适用于整个 Unity 项目。 它们可能被用于管理 C# 脚本内的关系，但这只有全体中的一个部分。
 
 |功能|通过 Unity 提供支持|其他注释|
 |-------------|--------------------------|-------------------------|
@@ -59,19 +59,19 @@ Visual Studio、Azure DevOps Services 和 Team Foundation Server 提供了各种
 
 |功能|通过 Unity 提供支持|其他注释|
 |-------------|--------------------------|-------------------------|
-|[使用 Team Foundation 版本控制 (TFVC)](/azure/devops/repos/tfvc/overview?view=vsts) 或 Azure Repos|是|像其他项目一样，Unity 项目仅可放入版本控制系统的文件集合，但有几点需要特别注意，见此表后所述内容。|
+|[使用 Team Foundation 版本控制 (TFVC)](/azure/devops/repos/tfvc/overview?view=vsts) 或 Azure Repos|是|Unity项目只是一个文件集合，可以像任何其他项目一样放置到版本控制系统中，但有几点需要特别注意，见此表后所述内容。|
 |[Azure Repos 中的 Git 入门](/azure/devops/repos/git/gitquickstart?view=vsts&tabs=visual-studio)|是|请参阅表后的注释。|
 |[提高代码质量](../test/improve-code-quality.md)|是||
 |[查找代码更改和其他历史记录](../ide/find-code-changes-and-other-history-with-codelens.md)|是||
 |[使用代码图调试应用程序](../modeling/use-code-maps-to-debug-your-applications.md)|是||
 
-使用 Unity 进行版本控制的特殊注意事项：
+ Unity 版本控制的特殊注意事项：
 
-1. Unity 跟踪默认情况下为隐藏且单一、不透明的库中有关游戏资产的元数据。 若要使文件和元数据保持同步，有必要使元数据可见，并将其保保存在更加易于管理的区块中。 有关详细信息，请参阅 [Using External Version Control Systems with Unity](http://docs.unity3d.com/Manual/ExternalVersionControlSystemSupport.html)（将 Unity 与外部版本控制系统配合使用）（Unity 文档）。
+1. Unity 使用一个默认情况下隐藏的不透明库来追踪和游戏资产相关的元数据。若要使文件和元数据保持同步，有必要使元数据可见，并将其保存在更加易于管理的区块中。 有关详细信息，请参阅 [Using External Version Control Systems with Unity](http://docs.unity3d.com/Manual/ExternalVersionControlSystemSupport.html)（将 Unity 与外部版本控制系统配合使用）（Unity 文档）。
 
-2. 并非 Unity 项目中的所有文件和文件夹都适合源代码管理，这同样在上面的链接中进行了描述。 应当添加资产和 ProjectSettings 文件夹，但不应添加库和临时文件夹。 有关所生成的不会进入源代码管理的文件的附加列表，请参阅 StackOverflow 上的讨论[如何使用 Git 进行 Unity3D 源代码管理？](http://stackoverflow.com/questions/18225126/how-to-use-git-for-unity3d-source-control)。 许多开发人员都针对此主题发表了博客。
+2. 并非 Unity 项目中的所有文件和文件夹都适合源代码管理，这同样在上面的链接中进行了描述。 应当添加 Assets 和 ProjectSettings 文件夹，但不应添加 Library 和 Temp 文件夹。 有关所生成的不会进入源代码管理的文件的附加列表，请参阅 StackOverflow 上的讨论[如何使用 Git 进行 Unity3D 源代码管理？](http://stackoverflow.com/questions/18225126/how-to-use-git-for-unity3d-source-control)。 许多开发人员都针对此主题发表了博客。
 
-3. Unity 项目中的二进制资产 — 例如纹理或音频文件 — 可能占用大理存储。 Git 等各种源代码管理系统为所做的每一次更改都保留一份唯一的副本，即使更改仅影响该文件的一小部分。 这会导致 Git 存储库变得臃肿。 若要解决此问题，Unity 开发人员通常仅选择将向其存储库添加最终的资产，并使用其他方式保留其资产的工作历史记录，例如 OneDrive、DropBox 或 git-annex。 这种方法有效，因为这种资产通常无需随源代码更改而进行版本控制。 开发人员通常也将项目编辑器的资产序列化模式设置为强制文本，以便以文本格式保存场景文件，而不是允许在源代码管理中进行合并的二进制格式。 有关详细信息，请参阅 [Editor Settings](http://docs.unity3d.com/Manual/class-EditorManager.html)（编辑器设置）（Unity 文档）。
+3. Unity 项目中的二进制资产 — 例如纹理或音频文件 — 可能占用大量的存储空间。 Git 等各种源代码管理系统为所做的每一次更改都保留一份唯一的副本，即使更改仅影响该文件的一小部分。 这会导致 Git 存储库变得臃肿。 为了解决这个问题，Unity 开发人员通常选择仅将最终资产添加到其存储库中，并使用不同的方法来保留其资产的工作历史记录，例如OneDrive，DropBox或git-annex。 此方法有效，因为此类资产通常不需要与源代码更改一起进行版本控制。 开发人员通常还会将项目编辑器的 Asset Serialization Mode 设置为 Force Text ，以便以文本而不是二进制格式存储场景文件，从而允许在源代码管理中进行合并。 有关详细信息，请参阅 [Editor Settings](http://docs.unity3d.com/Manual/class-EditorManager.html)（编辑器设置）（Unity 文档）。
 
 ## <a name="build"></a>生成
 
@@ -102,20 +102,20 @@ Visual Studio、Azure DevOps Services 和 Team Foundation Server 提供了各种
 
 |功能|通过 Unity 提供支持|其他注释|
 |-------------|--------------------------|-------------------------|
-|[分析托管代码的质量](../code-quality/analyzing-managed-code-quality-by-using-code-analysis.md)|是|可以分析 Visual Studio 中的 C# 脚本代码。|
-|[使用代码克隆检测功能查找重复代码](https://msdn.microsoft.com/library/hh205279.aspx)|是|可以分析 Visual Studio 中的 C# 脚本代码。|
-|[测量托管代码的复杂性和可维护性](../code-quality/measuring-complexity-and-maintainability-of-managed-code.md)|是|可以分析 Visual Studio 中的 C# 脚本代码。|
-|[性能资源管理器](../profiling/performance-explorer.md)|否|使用 [Unity 探查器](http://docs.unity3d.com/Manual/Profiler.html)（Unity 网站）。|
-|[分析 .NET Framework 内存问题](https://msdn.microsoft.com/library/dn342825.aspx)|否|Visual Studio 工具没有深入 Mono 框架（用于 Unity）进行探查的挂钩。 使用 [Unity 探查器](http://docs.unity3d.com/Manual/Profiler.html)（Unity 文档）。|
+|[分析托管代码的质量](../code-quality/analyzing-managed-code-quality-by-using-code-analysis.md)|是|可以在 Visual Studio 中分析 C# 脚本代码。|
+|[使用代码克隆检测功能查找重复代码](https://msdn.microsoft.com/library/hh205279.aspx)|是|可以在 Visual Studio 中分析 C# 脚本代码。|
+|[测量托管代码的复杂性和可维护性](../code-quality/measuring-complexity-and-maintainability-of-managed-code.md)|是|可以在 Visual Studio 中分析 C# 脚本代码。|
+|[性能资源管理器](../profiling/performance-explorer.md)|否|使用 [Unity Profiler](http://docs.unity3d.com/Manual/Profiler.html)（Unity 网站）。|
+|[分析 .NET Framework 内存问题](https://msdn.microsoft.com/library/dn342825.aspx)|否|Visual Studio 工具没有深入 Mono 框架（用于 Unity）进行探查的挂钩。 使用 [Unity Profiler](http://docs.unity3d.com/Manual/Profiler.html)（Unity 文档）。|
 
-## <a name="release-management"></a>版本管理
+## <a name="release-management"></a>发布管理
 
 参考链接：[Azure Pipelines 和 TFS 中的生成和发布](/azure/devops/pipelines/overview?view=vsts)
 
 |功能|通过 Unity 提供支持|其他注释|
 |-------------|--------------------------|-------------------------|
 |管理发布进程|是||
-|通过脚本部署到旁加载的服务器|是||
+|部署到服务器以通过脚本进行侧载|是||
 |上载到应用商店|部分|提供了一些扩展，这些扩展可使某些应用商店的此进程自动化。 请参阅 [Azure DevOps Services 扩展](https://marketplace.visualstudio.com/VSTS)；例如，[Google Play 扩展](https://marketplace.visualstudio.com/items?itemName=ms-vsclient.google-play)。|
 
 ## <a name="monitor-with-hockeyapp"></a>使用 HockeyApp 进行监控
@@ -124,4 +124,4 @@ Visual Studio、Azure DevOps Services 和 Team Foundation Server 提供了各种
 
 |功能|通过 Unity 提供支持|其他注释|
 |-------------|--------------------------|-------------------------|
-|故障分析、遥测和 beta 版本分发|是|HockeyApp 主要用于处理 beta 版本分布和获取故障报告。<br /><br /> 对于 C# 脚本中的遥测，则可以使用任何分析框架，前提是它在运行时使用的 .NET 版本也用于 Unity。 但是，这仅允许在游戏脚本内进行分析，而不是更加深入 Unity 引擎内部。 目前，没有任何适用于 Application Insights 的插件，但有适用于其他分析解决方案的插件，例如 [Unity 分析](https://www.assetstore.unity3d.com/en/#!/content/28120)和 [Google 分析](https://github.com/googleanalytics/google-analytics-plugin-for-unity)。 当然，了解 Unity 项目本质的 Unity 分析等服务将提供更多比一般框架更有意义的分析。|
+|故障分析、遥测和 beta 版本分发|是|HockeyApp 主要用于处理 beta 版本分发和获取崩溃报告。<br /><br /> 对于 C# 脚本中的遥测，则可以使用任何分析框架，前提是它在运行时使用的 .NET 版本也用于 Unity。 但是，这仅允许在游戏脚本内进行分析，而不是更加深入 Unity 引擎内部。 目前，没有任何适用于 Application Insights 的插件，但有适用于其他分析解决方案的插件，例如 [Unity Analytics](https://www.assetstore.unity3d.com/en/#!/content/28120)和 [Google Analytics](https://github.com/googleanalytics/google-analytics-plugin-for-unity)。 当然，了解 Unity 项目本质的 Unity Analytics 等服务将提供更多比一般框架更有意义的分析。|


### PR DESCRIPTION
1.Unity的特殊文件夹名称不应该被翻译。e.g：Assets
2.Unity Analytics是一个工具的名字，不应该被翻译。
3.修改不通顺的语句。